### PR TITLE
added support for a request transformer handler 

### DIFF
--- a/src/main/java/io/vertx/httpproxy/HttpProxy.java
+++ b/src/main/java/io/vertx/httpproxy/HttpProxy.java
@@ -30,6 +30,9 @@ public interface HttpProxy extends Handler<HttpServerRequest> {
   @Fluent
   HttpProxy selector(Function<HttpServerRequest, Future<SocketAddress>> selector);
 
+  @Fluent
+  HttpProxy requestTransformer(Function<ProxyRequest, Future<ProxyRequest>> filter);
+
   void handle(HttpServerRequest request);
 
   ProxyRequest proxy(HttpServerRequest request, SocketAddress target);

--- a/src/main/java/io/vertx/httpproxy/HttpProxy.java
+++ b/src/main/java/io/vertx/httpproxy/HttpProxy.java
@@ -31,7 +31,10 @@ public interface HttpProxy extends Handler<HttpServerRequest> {
   HttpProxy selector(Function<HttpServerRequest, Future<SocketAddress>> selector);
 
   @Fluent
-  HttpProxy requestTransformer(Function<ProxyRequest, Future<ProxyRequest>> filter);
+  HttpProxy proxyRequestTransformer(Function<ProxyRequest, Future<ProxyRequest>> filter);
+
+  @Fluent
+  HttpProxy proxyResponseTransformer(Function<ProxyResponse, Future<ProxyResponse>> filter);
 
   void handle(HttpServerRequest request);
 

--- a/src/main/java/io/vertx/httpproxy/ProxyRequest.java
+++ b/src/main/java/io/vertx/httpproxy/ProxyRequest.java
@@ -26,6 +26,10 @@ public interface ProxyRequest {
    */
   MultiMap headers();
 
+  String path();
+
+  String method();
+
   @Fluent
   ProxyRequest bodyFilter(Function<ReadStream<Buffer>, ReadStream<Buffer>> filter);
 

--- a/src/main/java/io/vertx/httpproxy/impl/ProxyRequestImpl.java
+++ b/src/main/java/io/vertx/httpproxy/impl/ProxyRequestImpl.java
@@ -90,6 +90,16 @@ public class ProxyRequestImpl implements ProxyRequest {
     return headers;
   }
 
+  @Override
+  public String path() {
+    return frontRequest.path();
+  }
+
+  @Override
+  public String method() {
+    return frontRequest.method().toString();
+  }
+
   private void copyHeaders(MultiMap to) {
     // Set headers, don't copy host, as HttpClient will set it
     for (Map.Entry<String, String> header : frontRequest.headers()) {


### PR DESCRIPTION
and two new getters for path and method in ProxyRequest

This allows one to modify requests sent to the proxy on the fly.

One use case is proxying requests for amazon S3:
- S3 requests need to have a signature hash which includes among other things the host header. 
- The proxy will modify that header obviously
- Thus the hash of the frontend request will be rejected by the S3 backend because it doesn't match the hash it computes.

This new handler is supposed to handle that sort of logic.